### PR TITLE
Remove encoding declaration in Python files

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 __version__ = "0.1.0"
 
 # flake8: noqa

--- a/app/application.py
+++ b/app/application.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from fastapi import FastAPI
 from . import __version__
 from .routes import router

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from fastapi.routing import APIRouter
 from . import v1
 

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from .singleton import Singleton, SingletonThreadSafe  # noqa F401
 
 

--- a/app/utils/date.py
+++ b/app/utils/date.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from calendar import timegm
 from datetime import datetime, timedelta, date
 

--- a/app/utils/parser.py
+++ b/app/utils/parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from urllib.parse import urlparse
 from ..platforms import PlatformType
 

--- a/app/utils/singleton.py
+++ b/app/utils/singleton.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import threading
 
 

--- a/app/v1/__init__.py
+++ b/app/v1/__init__.py
@@ -1,4 +1,1 @@
-# -*- coding: utf-8 -*-
-
-
 from .routes import router  # noqa: F401

--- a/app/v1/domain/errors/__init__.py
+++ b/app/v1/domain/errors/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # flake8: noqa
 
 from .item_not_found import ItemNotFoundError

--- a/app/v1/domain/errors/invalid_url.py
+++ b/app/v1/domain/errors/invalid_url.py
@@ -1,5 +1,2 @@
-# -*- coding: utf-8 -*-
-
-
 class InvalidURLError(Exception):
     pass

--- a/app/v1/domain/errors/item_not_found.py
+++ b/app/v1/domain/errors/item_not_found.py
@@ -1,5 +1,2 @@
-# -*- coding: utf-8 -*-
-
-
 class ItemNotFoundError(Exception):
     pass

--- a/app/v1/domain/link_type.py
+++ b/app/v1/domain/link_type.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from enum import Enum
 
 class LinkType(Enum):

--- a/app/v1/domain/platforms/__init__.py
+++ b/app/v1/domain/platforms/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # flake8: noqa
 
 from .apple_music import AppleMusicPlatform

--- a/app/v1/domain/platforms/apple_music.py
+++ b/app/v1/domain/platforms/apple_music.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import jwt
 from .platform import Platform

--- a/app/v1/domain/platforms/errors.py
+++ b/app/v1/domain/platforms/errors.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from enum import Enum
 
 

--- a/app/v1/domain/platforms/factory.py
+++ b/app/v1/domain/platforms/factory.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..platforms import PlatformType, SpotifyPlatform, AppleMusicPlatform
 
 

--- a/app/v1/domain/platforms/platform.py
+++ b/app/v1/domain/platforms/platform.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import abc
 import functools
 import requests

--- a/app/v1/domain/platforms/spotify.py
+++ b/app/v1/domain/platforms/spotify.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 from base64 import b64encode
 from .platform import Platform

--- a/app/v1/domain/platforms/types.py
+++ b/app/v1/domain/platforms/types.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from enum import Enum
 
 

--- a/app/v1/domain/types/__init__.py
+++ b/app/v1/domain/types/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # flake8: noqa
 
 from .sharify_object import SharifyObject

--- a/app/v1/domain/types/album.py
+++ b/app/v1/domain/types/album.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .sharify_object import SharifyObject
 
 

--- a/app/v1/domain/types/artist.py
+++ b/app/v1/domain/types/artist.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .sharify_object import SharifyObject
 
 

--- a/app/v1/domain/types/health.py
+++ b/app/v1/domain/types/health.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .sharify_object import SharifyObject
 
 

--- a/app/v1/domain/types/link_query.py
+++ b/app/v1/domain/types/link_query.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .sharify_object import SharifyObject
 
 

--- a/app/v1/domain/types/sharify_object.py
+++ b/app/v1/domain/types/sharify_object.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from abc import ABC
 
 

--- a/app/v1/domain/types/track.py
+++ b/app/v1/domain/types/track.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .sharify_object import SharifyObject
 
 

--- a/app/v1/routes.py
+++ b/app/v1/routes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from fastapi.routing import APIRouter
 from fastapi import Header, HTTPException
 from .versioning import VersionChanges

--- a/app/v1/services/__init__.py
+++ b/app/v1/services/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # flake8: noqa
 
 from .translation import TranslationService

--- a/app/v1/services/health.py
+++ b/app/v1/services/health.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..domain.platforms import PlatformFactory, PlatformType
 from ..domain.types import Health
 

--- a/app/v1/services/parse.py
+++ b/app/v1/services/parse.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 from ..domain.errors import InvalidURLError
 from ..domain.types import LinkQuery

--- a/app/v1/services/translation.py
+++ b/app/v1/services/translation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..domain.platforms import PlatformFactory, PlatformType
 from ..domain.link_type import LinkType
 from ..domain.errors import ItemNotFoundError

--- a/app/v1/versioning/__init__.py
+++ b/app/v1/versioning/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # flake8: noqa
 from .abstract_version_change import AbstractVersionChange
 from .version_changes import VersionChanges

--- a/app/v1/versioning/abstract_version_change.py
+++ b/app/v1/versioning/abstract_version_change.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from abc import ABC, abstractmethod
 from ..domain.types import SharifyObject
 

--- a/app/v1/versioning/changes/__init__.py
+++ b/app/v1/versioning/changes/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # flake8: noqa
 
 from .track_external_links import TrackExternalLinks

--- a/app/v1/versioning/changes/track_external_links.py
+++ b/app/v1/versioning/changes/track_external_links.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..abstract_version_change import AbstractVersionChange
 from ...domain.types import Track
 

--- a/app/v1/versioning/version_changes.py
+++ b/app/v1/versioning/version_changes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import changes  # noqa: F401
 from ...utils.singleton import Singleton
 from ..domain.types import SharifyObject

--- a/main.py
+++ b/main.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 from dotenv import load_dotenv
 from app.utils.cache import Cache

--- a/tests/platforms/__init__.py
+++ b/tests/platforms/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from .mock_platform import MockPlatform  # noqa: F401

--- a/tests/platforms/mock_platform.py
+++ b/tests/platforms/mock_platform.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from time import sleep
 from app.platforms.platform import Platform
 from app.utils.date import now

--- a/tests/platforms/test_platform.py
+++ b/tests/platforms/test_platform.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from unittest.mock import Mock, patch
 from threading import Thread
 from . import MockPlatform

--- a/tests/routes/test_factory.py
+++ b/tests/routes/test_factory.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from app.routes import RouterFactory
 
 

--- a/tests/routes/test_router.py
+++ b/tests/routes/test_router.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from unittest.mock import MagicMock
 from app.routes import Router
 

--- a/tests/services/test_default.py
+++ b/tests/services/test_default.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 SPOTIFY_TRACK_ID = '6voo8x5qmBvabjEOxPHesp'
 
 APPLE_MUSIC_TRACK_ID = '1490944380'

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from unittest.mock import MagicMock
 from app.application import ApplicationFactory
 


### PR DESCRIPTION
Since Python 3, all Python files are UTF-8 by default, so defining it in every file's header is unnecessary.

See: https://stackoverflow.com/questions/14083111/should-i-use-encoding-declaration-in-python-3